### PR TITLE
Add DB_PATH env support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your_openai_key
+DB_PATH=./asset_universe.duckdb

--- a/README.md
+++ b/README.md
@@ -61,18 +61,21 @@ Install all required packages from the requirements.txt file.
 
 pip install -r requirements.txt
 
-3. Set Up API Keys
-Create a .env file in the project root by copying the example file.
+3. Set Up Environment Variables
+Create a `.env` file in the project root by copying the example file.
 
 cp .env.example .env
 
-Now, edit the .env file and add your OpenAI API key.
+Edit the `.env` file and add your OpenAI API key.  You can also change
+`DB_PATH` if you want the DuckDB file stored somewhere else.
 
 ⚙️ How to Use
 There are two main parts to this project: running the data pipeline and viewing the dashboard.
 
 1. Run the Data Pipeline
-To discover, enrich, and score the assets, run the create_db.py script. This will generate the asset_universe.duckdb file that the dashboard reads from.
+Run `create_db.py` to discover, enrich, and score the assets. The
+database will be written to the location specified by `DB_PATH` (or
+`./asset_universe.duckdb` by default) for the dashboard to read.
 
 python create_db.py
 

--- a/api/publisher.py
+++ b/api/publisher.py
@@ -6,9 +6,8 @@ import os
 import time
 
 # --- Configuration ---
-# Use the absolute path to ensure the db is found
-PROJECT_ROOT = "/Users/zakariyaveasy/Desktop/ZKJ/quant-research-app/asset_universe.duckdb"
-DB_FILE = os.path.join(PROJECT_ROOT, "asset_universe.duckdb")
+# Read database path from the environment with a fallback
+DB_FILE = os.getenv("DB_PATH", "./asset_universe.duckdb")
 ZMQ_PORT = "5556"
 TOPIC = "UNIVERSE_TODAY"
 

--- a/backtester/core.py
+++ b/backtester/core.py
@@ -6,8 +6,8 @@ import vectorbt as vbt
 import os
 
 # --- Configuration ---
-PROJECT_ROOT = "/Users/zakariyaveasy/Desktop/ZKJ/quant-research-app/asset_universe.duckdb"
-DB_FILE = os.path.join(PROJECT_ROOT, "asset_universe.duckdb")
+# Use environment variable for the database location with a default
+DB_FILE = os.getenv("DB_PATH", "./asset_universe.duckdb")
 NUM_ASSETS_TO_TEST = 3
 
 

--- a/create_db.py
+++ b/create_db.py
@@ -13,9 +13,8 @@ from factors.quality import get_debt_to_equity, get_return_on_equity
 from factors.volatility import get_annualized_volatility
 from alt_data.trends import get_google_trends_score  # <--- NEW IMPORT
 
-# Set your project root directory (not the DB file itself)
-PROJECT_ROOT = "/Users/zakariyaveasy/Desktop/ZKJ/quant-research-app"
-DB_FILE = os.path.join(PROJECT_ROOT, "asset_universe.duckdb")
+# Read the database path from the environment with a sensible default
+DB_FILE = os.getenv("DB_PATH", "./asset_universe.duckdb")
 
 
 def save_candidates_to_db(candidates: list[dict]):


### PR DESCRIPTION
## Summary
- add `.env.example`
- read `DB_PATH` variable in `create_db.py`, `backtester/core.py`, and `api/publisher.py`
- update README instructions about `.env` and DB_PATH

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687053453ae0833398f8f6f53e6a1a24