### PR TITLE
Add FX carry and bond duration factors

### DIFF
--- a/factors/bond_duration.py
+++ b/factors/bond_duration.py
@@ -1,0 +1,33 @@
+# In: factors/bond_duration.py
+"""Utility for retrieving bond duration metrics."""
+
+import numpy as np
+import yfinance as yf
+
+
+def get_bond_duration(symbol: str) -> float:
+    """Fetch the duration for a bond ETF or instrument.
+
+    This function relies on the ``duration`` field returned by ``yfinance``.
+    If the value is missing or data cannot be fetched, ``np.nan`` is returned.
+
+    Args:
+        symbol: The bond ticker (e.g. ``"IEF"`` for a Treasury ETF).
+
+    Returns:
+        float: Duration in years or ``np.nan`` if unavailable.
+    """
+
+    try:
+        info = yf.Ticker(symbol).info
+        duration = info.get("duration")
+        if duration is not None:
+            return float(duration)
+        return np.nan
+    except Exception:
+        return np.nan
+
+
+# --- To test this function directly ---
+if __name__ == "__main__":
+    print("Duration for IEF:", get_bond_duration("IEF"))

--- a/factors/fx_carry.py
+++ b/factors/fx_carry.py
@@ -1,0 +1,56 @@
+# In: factors/fx_carry.py
+"""Functions to compute FX carry metrics."""
+
+import numpy as np
+import yfinance as yf
+
+# Mapping from currency codes to FRED tickers for short-term interest rates
+# We use 3-month interbank or treasury rates where available.
+CURRENCY_TO_FRED_TICKER = {
+    "USD": "DGS3MO",  # 3-Month Treasury Bill: Secondary Market Rate
+    "EUR": "EUR3MTD156N",  # Euro Area 3-Month interbank rate
+    "JPY": "IR3TIB01JPM156N",  # Japan 3-Month interbank rate
+    "GBP": "IR3TIB01GBM156N",  # U.K. 3-Month interbank rate
+    "AUD": "IR3TIB01AUM156N",  # Australia 3-Month interbank rate
+}
+
+
+def get_fx_carry(base_currency: str, quote_currency: str) -> float:
+    """Calculate the FX carry for a currency pair.
+
+    The carry is defined here as the short‑term interest rate differential
+    between the base currency you are long and the funding (quote) currency
+    you are short.
+
+    Args:
+        base_currency: ISO code of the currency you are long (e.g. ``"EUR"``).
+        quote_currency: ISO code of the currency you are short (e.g. ``"USD"``).
+
+    Returns:
+        float: Interest rate differential ``base - quote`` or ``np.nan`` if
+        data cannot be retrieved.
+    """
+    try:
+        base_ticker = CURRENCY_TO_FRED_TICKER[base_currency.upper()]
+        quote_ticker = CURRENCY_TO_FRED_TICKER[quote_currency.upper()]
+    except KeyError:
+        return np.nan
+
+    try:
+        base_data = yf.download(base_ticker, period="5d", progress=False)
+        quote_data = yf.download(quote_ticker, period="5d", progress=False)
+
+        if base_data.empty or quote_data.empty:
+            return np.nan
+
+        base_rate = base_data["Close"].dropna().iloc[-1]
+        quote_rate = quote_data["Close"].dropna().iloc[-1]
+
+        return float(base_rate - quote_rate)
+    except Exception:
+        return np.nan
+
+
+# --- To test this function directly ---
+if __name__ == "__main__":
+    print("EUR/USD carry:", get_fx_carry("EUR", "USD"))

--- a/tests/test_factors.py
+++ b/tests/test_factors.py
@@ -2,17 +2,28 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 
 # Import all the factor functions you've created
 from factors.value import get_price_to_book
 from factors.quality import get_debt_to_equity, get_return_on_equity
 from factors.momentum import get_12m_momentum
 from factors.volatility import get_annualized_volatility
+from factors.fx_carry import get_fx_carry
+from factors.bond_duration import get_bond_duration
 
 # --- Test Data ---
 # A list of symbols to test against. One likely to work, one likely to fail.
 VALID_SYMBOL = "AAPL"
 INVALID_SYMBOL = "INVALID_SYMBOL_XYZ"
+
+# FX test data
+FX_BASE = "EUR"
+FX_QUOTE = "USD"
+
+# Bond test data
+BOND_SYMBOL = "IEF"  # iShares 7-10 Year Treasury ETF
+INVALID_BOND = "INVALID_BOND"
 
 
 # --- Helper Function for Testing ---
@@ -55,3 +66,23 @@ def test_annualized_volatility():
     """Tests the Annualized Volatility factor."""
     check_factor_output(get_annualized_volatility(VALID_SYMBOL))
     assert pd.isna(get_annualized_volatility(INVALID_SYMBOL))
+
+
+def test_fx_carry():
+    """Tests the FX carry factor."""
+    value = get_fx_carry(FX_BASE, FX_QUOTE)
+    if pd.isna(value):
+        pytest.skip("FX carry data unavailable")
+    check_factor_output(value)
+
+    assert pd.isna(get_fx_carry("AAA", "BBB"))
+
+
+def test_bond_duration():
+    """Tests the bond duration factor."""
+    value = get_bond_duration(BOND_SYMBOL)
+    if pd.isna(value):
+        pytest.skip("Bond duration data unavailable")
+    check_factor_output(value)
+
+    assert pd.isna(get_bond_duration(INVALID_BOND))


### PR DESCRIPTION
## Summary
- add FX carry factor pulling short-term rates from FRED via `yfinance`
- add bond duration factor using `yfinance` metadata
- extend factor tests for new functions with skipping on missing data

## Testing
- `ruff check factors tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6870535491c48333843322c8bd8af02e