### PR TITLE
Add Federal Funds rate metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project is an end-to-end pipeline for discovering, enriching, and ranking f
     4.  **Carbon Credits**: Explore carbon credit opportunities.
     5.  **Green Bonds**: Browse green bond issuances with duration info.
 - **CI/CD Ready**: Includes a GitHub Actions workflow to automatically run tests on every push, ensuring code quality and stability.
+- **Fed Rate Tracking**: Pulls the latest Federal Funds Rate from FRED and records monthly changes to gauge borrowing conditions.
 
 ---
 

--- a/create_db.py
+++ b/create_db.py
@@ -12,6 +12,7 @@ from factors.momentum import get_12m_momentum
 from factors.quality import get_debt_to_equity, get_return_on_equity
 from factors.volatility import get_annualized_volatility
 from alt_data.trends import get_google_trends_score
+from factors.fed_rates import get_fed_funds_rate, get_fed_funds_rate_change
 from universe_scouter.explorers import EquityExplorer
 from universe_scouter.currency_explorer import get_assets as get_currency_assets
 from universe_scouter.carbon_credit_explorer import (
@@ -70,6 +71,10 @@ if __name__ == "__main__":
     )
     discovered_assets = discovery_df.to_dict("records")
 
+    # Fetch macro factors once
+    fed_rate = get_fed_funds_rate()
+    fed_change = get_fed_funds_rate_change()
+
     print(
         f"   - Starting with {len(discovered_assets)} assets: {[a['symbol'] for a in discovered_assets]}"
     )
@@ -93,6 +98,10 @@ if __name__ == "__main__":
             print(f"   - Google Trends Score for {asset['symbol']}: {trends_score:.2%}")
         else:
             print(f"   - Google Trends Score for {asset['symbol']}: Not Available")
+        if pd.notna(fed_rate):
+            print(f"   - Fed Funds Rate: {fed_rate:.2f}%")
+        if pd.notna(fed_change):
+            print(f"   - 30d Rate Change: {fed_change:.2f}")
         # ----------------------------
 
         if predict_score is not None and np.isfinite(predict_score):
@@ -104,6 +113,8 @@ if __name__ == "__main__":
             asset["return_on_equity"] = roe
             asset["annualized_volatility"] = ann_vol
             asset["google_trends_score"] = trends_score  # Add the new trends score
+            asset["fed_funds_rate"] = fed_rate
+            asset["fed_funds_rate_change"] = fed_change
 
             # Get the AI score and add it to the final record
             ai_result = get_ai_fit_score(asset["symbol"], asset, dev_mode=True)

--- a/dash_app/app.py
+++ b/dash_app/app.py
@@ -82,6 +82,10 @@ def load_candidates_from_db(asset_class: str | None = None):
             df['fx_carry'] = df['fx_carry'].apply(lambda x: f"{x:.2f}" if pd.notna(x) else "N/A")
         if 'bond_duration' in df.columns:
             df['bond_duration'] = df['bond_duration'].apply(lambda x: f"{x:.2f}" if pd.notna(x) else "N/A")
+        if 'fed_funds_rate' in df.columns:
+            df['fed_funds_rate'] = df['fed_funds_rate'].apply(lambda x: f"{x:.2f}%" if pd.notna(x) else "N/A")
+        if 'fed_funds_rate_change' in df.columns:
+            df['fed_funds_rate_change'] = df['fed_funds_rate_change'].apply(lambda x: f"{x:.2f}" if pd.notna(x) else "N/A")
 
         return df
     except Exception as e:
@@ -133,6 +137,8 @@ app.layout = dbc.Container([
                             {'name': 'Google Trends', 'id': 'google_trends_score'},
                             {'name': 'FX Carry', 'id': 'fx_carry'},
                             {'name': 'Duration', 'id': 'bond_duration'},
+                            {'name': 'Fed Funds Rate', 'id': 'fed_funds_rate'},
+                            {'name': 'Rate Change (30d)', 'id': 'fed_funds_rate_change'},
                             {'name': 'Recorded At', 'id': 'recorded_at'},
                             {'name': 'AI Rationale', 'id': 'rationale'},
                         ],
@@ -159,6 +165,8 @@ app.layout = dbc.Container([
                             {'name': 'AI Fit Score', 'id': 'fit_score'},
                             {'name': 'Predictability', 'id': 'predictability_score'},
                             {'name': 'FX Carry', 'id': 'fx_carry'},
+                            {'name': 'Fed Funds Rate', 'id': 'fed_funds_rate'},
+                            {'name': 'Rate Change (30d)', 'id': 'fed_funds_rate_change'},
                             {'name': 'Recorded At', 'id': 'recorded_at'},
                             {'name': 'AI Rationale', 'id': 'rationale'},
                         ],

--- a/factors/fed_rates.py
+++ b/factors/fed_rates.py
@@ -1,0 +1,36 @@
+# In: factors/fed_rates.py
+"""Utilities for retrieving Federal Reserve interest rate metrics."""
+
+import numpy as np
+import yfinance as yf
+
+
+def get_fed_funds_rate() -> float:
+    """Fetch the latest effective Federal Funds Rate (FRED ticker 'DFF')."""
+    try:
+        data = yf.download("DFF", period="5d", progress=False)
+        if data.empty:
+            return np.nan
+        return float(data["Close"].dropna().iloc[-1])
+    except Exception:
+        return np.nan
+
+
+def get_fed_funds_rate_change(days: int = 30) -> float:
+    """Return the change in the effective Fed Funds Rate over the given period."""
+    try:
+        data = yf.download("DFF", period=f"{days}d", progress=False)
+        closes = data["Close"].dropna()
+        if len(closes) < 2:
+            return np.nan
+        return float(closes.iloc[-1] - closes.iloc[0])
+    except Exception:
+        return np.nan
+
+
+# --- To test this module directly ---
+if __name__ == "__main__":
+    rate = get_fed_funds_rate()
+    change = get_fed_funds_rate_change()
+    print("Fed Funds Rate:", rate)
+    print("1M Change:", change)

--- a/tests/test_factors.py
+++ b/tests/test_factors.py
@@ -11,6 +11,7 @@ from factors.momentum import get_12m_momentum
 from factors.volatility import get_annualized_volatility
 from factors.fx_carry import get_fx_carry
 from factors.bond_duration import get_bond_duration
+from factors.fed_rates import get_fed_funds_rate, get_fed_funds_rate_change
 
 # --- Test Data ---
 # A list of symbols to test against. One likely to work, one likely to fail.
@@ -86,3 +87,19 @@ def test_bond_duration():
     check_factor_output(value)
 
     assert pd.isna(get_bond_duration(INVALID_BOND))
+
+
+def test_fed_funds_rate():
+    """Tests fetching the Fed Funds rate."""
+    value = get_fed_funds_rate()
+    if pd.isna(value):
+        pytest.skip("Fed funds data unavailable")
+    check_factor_output(value)
+
+
+def test_fed_funds_rate_change():
+    """Tests the change in the Fed Funds rate."""
+    value = get_fed_funds_rate_change()
+    if pd.isna(value):
+        pytest.skip("Fed funds trend data unavailable")
+    assert isinstance(value, (float, np.floating))


### PR DESCRIPTION
## Summary
- fetch the Federal Funds rate and 30-day change via new `factors.fed_rates`
- capture those macro metrics in the main data pipeline
- display the rate metrics in the dashboard tables
- test new factor functions
- document Fed rate tracking in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6872b3b647448333a31ddee376c5956a