### PR TITLE
Add SEC filing fetch utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project is an end-to-end pipeline for discovering, enriching, and ranking f
 - **AI Asset Scoring**: Uses an AI agent (in developer mode) to provide a "Fit Score" and rationale for each asset's suitability.
 - **Supply Chain Explorer**: Suggests supplier stocks for major tech companies like Nvidia or Apple.
 - **Data Lake Storage**: Saves enriched asset data to fast Parquet files and logs metadata in a DuckDB database for quick queries.
+- **SEC Filing Summaries**: Fetches the latest filings and uses GPT-4o to summarize risks.
 - **Interactive Dashboard**: A multi-tab Dash application for:
     1.  **PCA Factor Analysis**: Visualize latent factors across a basket of stocks.
     2.  **Equities Scout**: Review the AI-scored equity candidates.

--- a/alt_data/__init__.py
+++ b/alt_data/__init__.py
@@ -1,0 +1,2 @@
+from .trends import get_google_trends_score
+from .sec_filings import fetch_latest_filing_text, summarize_filing

--- a/alt_data/sec_filings.py
+++ b/alt_data/sec_filings.py
@@ -1,0 +1,92 @@
+import os
+import json
+import requests
+from trafilatura import extract
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv()
+
+HEADERS = {"User-Agent": "quant-research-app/0.1 contact@example.com"}
+TICKER_URL = "https://www.sec.gov/files/company_tickers.json"
+
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+
+
+def _get_cik(ticker: str) -> str | None:
+    """Return the zero-padded CIK for a given ticker."""
+    try:
+        resp = requests.get(TICKER_URL, headers=HEADERS, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        for entry in data.values():
+            if entry["ticker"].lower() == ticker.lower():
+                return str(entry["cik_str"]).zfill(10)
+    except Exception:
+        return None
+    return None
+
+
+def _get_filing_url(cik: str, form_type: str) -> str | None:
+    """Fetch the filing metadata and return the document URL."""
+    try:
+        url = f"https://data.sec.gov/submissions/CIK{cik}.json"
+        resp = requests.get(url, headers=HEADERS, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        recent = data.get("filings", {}).get("recent", {})
+        for form, acc, doc in zip(
+            recent.get("form", []),
+            recent.get("accessionNumber", []),
+            recent.get("primaryDocument", []),
+        ):
+            if form == form_type:
+                acc_no = acc.replace("-", "")
+                return (
+                    "https://www.sec.gov/Archives/edgar/data/"
+                    f"{int(cik)}/{acc_no}/{doc}"
+                )
+    except Exception:
+        return None
+    return None
+
+
+def fetch_latest_filing_text(ticker: str, form_type: str = "10-K") -> str:
+    """Download the latest filing text for a ticker."""
+    cik = _get_cik(ticker)
+    if not cik:
+        return ""
+    filing_url = _get_filing_url(cik, form_type)
+    if not filing_url:
+        return ""
+    try:
+        resp = requests.get(filing_url, headers=HEADERS, timeout=10)
+        resp.raise_for_status()
+        return extract(resp.text) or ""
+    except Exception:
+        return ""
+
+
+def summarize_filing(text: str) -> dict:
+    """Use GPT-4o to summarize the filing and provide a risk rating."""
+    if not text:
+        return {}
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Summarize the key points of the SEC filing and provide a "
+                        "risk rating from 1 (low) to 5 (high) as JSON."
+                    ),
+                },
+                {"role": "user", "content": text[:12000]},
+            ],
+            response_format={"type": "json_object"},
+            temperature=0.3,
+        )
+        return json.loads(response.choices[0].message.content)
+    except Exception:
+        return {}

--- a/tests/test_sec_filings.py
+++ b/tests/test_sec_filings.py
@@ -1,0 +1,43 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from alt_data.sec_filings import fetch_latest_filing_text
+
+
+class DummyResp:
+    def __init__(self, text="", json_data=None):
+        self.text = text
+        self._json = json_data or {}
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._json
+
+
+def fake_get(url, headers=None, timeout=10):
+    if "company_tickers.json" in url:
+        return DummyResp(json_data={"0": {"cik_str": 320193, "ticker": "AAPL"}})
+    if "CIK0000320193.json" in url:
+        data = {
+            "filings": {
+                "recent": {
+                    "form": ["10-K"],
+                    "accessionNumber": ["0000320193-23-000106"],
+                    "primaryDocument": ["aapl-20230930.htm"],
+                }
+            }
+        }
+        return DummyResp(json_data=data)
+    if "aapl-20230930.htm" in url:
+        return DummyResp("<html>Filing Text AAPL</html>")
+    raise RuntimeError("Unexpected URL")
+
+
+def test_fetch_latest_filing_text(monkeypatch):
+    monkeypatch.setattr("requests.get", fake_get)
+    text = fetch_latest_filing_text("AAPL")
+    assert "Filing Text AAPL" in text


### PR DESCRIPTION
## Summary
- fetch SEC filings directly from the EDGAR site
- summarize filings with GPT-4o
- expose new functions via `alt_data` package
- document the new SEC filing feature
- test the network logic with mocked responses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6872b41dc31c8333bec2300f17d53742