### PR TITLE
Add predictive maintenance and policy modules

### DIFF
--- a/aiops/predictor.py
+++ b/aiops/predictor.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Dict, List
+
+import requests
+import torch
+import torch.nn as nn
+import numpy as np
+
+ALERTMANAGER_URL = os.getenv("ALERTMANAGER_URL", "http://alertmanager:9093/api/v1/alerts")
+REMOTE_WRITE_ENDPOINT = os.getenv("REMOTE_WRITE_ENDPOINT", "http://prometheus:9090/api/v1/write")
+METRICS_URL = os.getenv("NODE_EXPORTER_URL", "http://localhost:9100/metrics")
+WINDOW = int(os.getenv("LSTM_WINDOW", "30"))
+
+
+class LSTMModel(nn.Module):
+    def __init__(self, features: int, hidden: int = 32):
+        super().__init__()
+        self.lstm = nn.LSTM(features, hidden, batch_first=True)
+        self.fc = nn.Linear(hidden, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out, _ = self.lstm(x)
+        out = out[:, -1, :]
+        return torch.sigmoid(self.fc(out))
+
+
+def parse_metrics(text: str) -> Dict[str, float]:
+    out: Dict[str, float] = {}
+    for line in text.splitlines():
+        if line.startswith("node_load1"):
+            out["load1"] = float(line.split()[-1])
+        if line.startswith("node_memory_MemAvailable_bytes"):
+            out["mem_avail"] = float(line.split()[-1])
+    return out
+
+
+def fetch_metrics() -> Dict[str, float]:
+    r = requests.get(METRICS_URL, timeout=5)
+    r.raise_for_status()
+    return parse_metrics(r.text)
+
+
+def remote_write(metrics: Dict[str, float]) -> None:
+    # Simplified remote write as JSON for demo purposes
+    requests.post(REMOTE_WRITE_ENDPOINT, json=metrics, timeout=5)
+
+
+def send_alert(prob: float) -> None:
+    alert = [
+        {
+            "labels": {"alertname": "NodeFailurePredicted"},
+            "annotations": {"summary": f"failure_prob={prob:.2f}"},
+        }
+    ]
+    requests.post(ALERTMANAGER_URL, json=alert, timeout=5)
+
+
+def train_model(data: List[Dict[str, float]]) -> LSTMModel:
+    arr = np.array([[d["load1"], d["mem_avail"]] for d in data], dtype=np.float32)
+    X = []
+    y = []
+    for i in range(len(arr) - WINDOW - 1):
+        X.append(arr[i : i + WINDOW])
+        y.append(arr[i + WINDOW, 0])
+    X_t = torch.tensor(np.stack(X))
+    y_t = torch.tensor(y).unsqueeze(1)
+    model = LSTMModel(features=2)
+    loss_fn = nn.MSELoss()
+    opt = torch.optim.Adam(model.parameters())
+    for _ in range(50):
+        opt.zero_grad()
+        out = model(X_t)
+        loss = loss_fn(out, y_t)
+        loss.backward()
+        opt.step()
+    return model
+
+
+def main() -> None:
+    history: List[Dict[str, float]] = []
+    model: LSTMModel | None = None
+    while True:
+        metrics = fetch_metrics()
+        remote_write(metrics)
+        history.append(metrics)
+        if len(history) > WINDOW * 2:
+            model = train_model(history[-WINDOW * 2 :])
+            seq = torch.tensor([[metrics["load1"], metrics["mem_avail"]]], dtype=torch.float32).unsqueeze(0)
+            prob = float(model(seq))
+            if prob > 0.8:
+                send_alert(prob)
+        time.sleep(60)
+
+
+if __name__ == "__main__":
+    main()

--- a/k8s_drain_hook.py
+++ b/k8s_drain_hook.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from flask import Flask, request
+from kubernetes import client, config
+
+app = Flask(__name__)
+
+
+def cordon_and_drain(node_name: str) -> None:
+    v1 = client.CoreV1Api()
+    # cordon
+    v1.patch_node(node_name, {"spec": {"unschedulable": True}})
+    # drain respecting PDBs via eviction API
+    pods = v1.list_pod_for_all_namespaces(field_selector=f"spec.nodeName={node_name}").items
+    for p in pods:
+        if p.metadata.owner_references and any(o.kind == "DaemonSet" for o in p.metadata.owner_references):
+            continue
+        body = client.V1Eviction(metadata=client.V1ObjectMeta(name=p.metadata.name, namespace=p.metadata.namespace))
+        try:
+            v1.create_namespaced_pod_eviction(p.metadata.name, p.metadata.namespace, body)
+        except client.exceptions.ApiException:
+            pass
+
+
+@app.route("/hook", methods=["POST"])
+def hook() -> tuple[str, int]:
+    data: dict[str, Any] = request.get_json(force=True)
+    for alert in data.get("alerts", []):
+        node = alert.get("labels", {}).get("node")
+        if node:
+            cordon_and_drain(node)
+    return "ok", 200
+
+
+def main() -> None:
+    if os.getenv("KUBERNETES_SERVICE_HOST"):
+        config.load_incluster_config()
+    else:
+        config.load_kube_config()
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "8080")))
+
+
+if __name__ == "__main__":
+    main()

--- a/policy/policy_dsl_schema.yaml
+++ b/policy/policy_dsl_schema.yaml
@@ -1,0 +1,22 @@
+type: object
+properties:
+  max_drawdown_pct:
+    type: number
+    minimum: 0
+    maximum: 1
+  max_notional:
+    type: number
+    minimum: 0
+  allowed_hours:
+    type: array
+    items:
+      type: integer
+      minimum: 0
+      maximum: 23
+  banned_symbols:
+    type: array
+    items:
+      type: string
+required:
+  - max_drawdown_pct
+  - max_notional

--- a/policy/policy_evaluator.py
+++ b/policy/policy_evaluator.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+import grpc
+import yaml
+import jsonschema
+import redis
+
+SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "policy_dsl_schema.yaml")
+
+
+def load_policy(path: str) -> Dict[str, Any]:
+    with open(SCHEMA_PATH) as f:
+        schema = yaml.safe_load(f)
+    with open(path) as f:
+        policy = yaml.safe_load(f)
+    jsonschema.validate(policy, schema)
+    return policy
+
+
+def check_action(action: Dict[str, Any], policy: Dict[str, Any]) -> bool:
+    if action.get("drawdown_pct", 0) > policy["max_drawdown_pct"]:
+        return False
+    if action.get("notional", 0) > policy["max_notional"]:
+        return False
+    hour = action.get("hour")
+    if policy.get("allowed_hours") and hour not in policy["allowed_hours"]:
+        return False
+    if action.get("symbol") in policy.get("banned_symbols", []):
+        return False
+    return True
+
+
+class PolicyInterceptor(grpc.ServerInterceptor):
+    def __init__(self, policy_path: str, redis_url: str = "redis://localhost:6379"):
+        self.policy = load_policy(policy_path)
+        self.redis = redis.from_url(redis_url)
+
+    def intercept_service(self, continuation, handler_call_details):
+        handler = continuation(handler_call_details)
+
+        def wrapper(request, context):
+            action = json.loads(request.action_json) if hasattr(request, "action_json") else {}
+            if not check_action(action, self.policy):
+                self.redis.xadd("policy-violations", {"action": json.dumps(action)})
+                context.abort(grpc.StatusCode.PERMISSION_DENIED, "policy violation")
+            return handler(request, context)
+
+        return grpc.unary_unary_rpc_method_handler(wrapper)


### PR DESCRIPTION
## Summary
- stream node-exporter metrics and forecast failures via LSTM
- drain Kubernetes nodes on Alertmanager webhooks
- define YAML schema for agent policies
- evaluate policies via gRPC interceptor with Redis logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: pandas, duckdb, moto, vcr, zmq, pytrends)*

------
https://chatgpt.com/codex/tasks/task_e_6876adb1d6e88333bba05699d0e430c2